### PR TITLE
Add `async` method to exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,25 @@
 'use strict';
-module.exports = function (str, opts) {
-  var request = require('sync-request');
 
-  var options_obj = {
-    'headers': {
-      'user-agent': 'http://github.com/icyflame/gh-gist-owner'
-    }
-  };
-  var res = request('GET', 'https://api.github.com/gists/' + str, options_obj);
+var asyncRequest = require('then-request');
+var syncRequest = require('sync-request');
 
-  var body = JSON.parse(res.getBody());
+var options = {
+  'headers': {
+    'user-agent': 'http://github.com/icyflame/gh-gist-owner'
+  }
+};
 
-  return body.owner.login;
+var url = function (id) {
+  return 'https://api.github.com/gists/' + id;
+};
 
+exports.sync = function (str) {
+  var res = syncRequest('GET', url(str), options);
+  return JSON.parse(res.getBody()).owner.login;
+};
+
+exports.async = function (str, cb) {
+  asyncRequest('GET', url(str), options).done(function (res) {
+    cb(JSON.parse(res.getBody()).owner.login);
+  });
 };

--- a/index.js
+++ b/index.js
@@ -13,13 +13,25 @@ var url = function (id) {
   return 'https://api.github.com/gists/' + id;
 };
 
-exports.sync = function (str) {
+module.exports = function (str) {
   var res = syncRequest('GET', url(str), options);
   return JSON.parse(res.getBody()).owner.login;
 };
 
-exports.async = function (str, cb) {
-  asyncRequest('GET', url(str), options).done(function (res) {
-    cb(JSON.parse(res.getBody()).owner.login);
-  });
+module.exports.sync = module.exports;
+
+module.exports.async = function (str, cb) {
+  asyncRequest(
+    'GET',
+    url(str),
+    options,
+    function (err, res) {
+      var data = err
+        ? null
+        : JSON.parse(
+            res.getBody()
+        ).owner.login;
+
+      cb(err, data);
+    });
 };

--- a/package.json
+++ b/package.json
@@ -33,10 +33,11 @@
   ],
   "dependencies": {
     "meow": "^3.0.0",
-    "sync-request": "^2.0.1"
+    "sync-request": "^2.0.1",
+    "then-request": "^2.2.0"
   },
   "devDependencies": {
     "mocha": "*",
-    "semistandard": "^6.1.1"
+    "semistandard": "^7.0.2"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -18,10 +18,15 @@ $ npm install --save gh-gist-owner
 ```js
 var ghGistOwner = require('gh-gist-owner');
 
-ghGistOwner('gist-id');
-// owner-github-username
-ghGistOwner('420166ca54b7afe55476');
+ghGistOwner('420166ca54b7afe55476'); // or ghGistOwner.sync
 //=> icyflame
+
+ghGistOwner.async(
+  '420166ca54b7afe55476',
+  function (err, user) {
+    //=> user = icyflame
+  }
+);
 ```
 
 
@@ -47,18 +52,27 @@ $ gh-gist-owner --help
 
 ## API
 
-### ghGistOwner(gist_id)
+### `ghGistOwner(gist_id)` / `ghGistOwner.sync(gist_id)`
 
-#### gist_id
+#### `gist_id`
 
-*Required*  
 Type: `string`
 
-ID of the gist
-Something like 420166ca54b7afe55476, which can be found at
+ID of the gist. Something like [`420166ca54b7afe55476`](https://gist.github.com/icyflame/420166ca54b7afe55476)
 
-https://gist.github.com/icyflame/420166ca54b7afe55476
+### `ghGistOwner.async(gist_id, callback)`
 
+#### `gist_id`
+
+Type: `string`
+
+ID of the gist. Something like [`420166ca54b7afe55476`](https://gist.github.com/icyflame/420166ca54b7afe55476)
+
+#### `callback`
+
+Type: `function`
+
+This should take two arguments: `err` and `user`, where `err` is the request error (or `null` if everything worked), and `user` is the name of the gist owner.
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -4,6 +4,10 @@
 var assert = require('assert');
 var ghGistOwner = require('./');
 
+it('defaults correctly', function () {
+  assert.strictEqual(ghGistOwner, ghGistOwner.sync);
+});
+
 it('gets the owner', function () {
   assert.strictEqual(
     ghGistOwner.sync('420166ca54b7afe55476'),
@@ -14,8 +18,9 @@ it('gets the owner', function () {
 it('gets the owner asynchronously', function (done) {
   ghGistOwner.async(
     '420166ca54b7afe55476',
-    function (owner) {
+    function (err, owner) {
       assert.strictEqual(owner, 'icyflame');
+      assert.strictEqual(err, null);
       done();
     }
   );

--- a/test.js
+++ b/test.js
@@ -1,8 +1,22 @@
 /* global it */
 'use strict';
+
 var assert = require('assert');
 var ghGistOwner = require('./');
 
-it('should ', function () {
-  assert.strictEqual(ghGistOwner('420166ca54b7afe55476'), 'icyflame');
+it('gets the owner', function () {
+  assert.strictEqual(
+    ghGistOwner.sync('420166ca54b7afe55476'),
+    'icyflame'
+  );
+});
+
+it('gets the owner asynchronously', function (done) {
+  ghGistOwner.async(
+    '420166ca54b7afe55476',
+    function (owner) {
+      assert.strictEqual(owner, 'icyflame');
+      done();
+    }
+  );
 });


### PR DESCRIPTION
Hello!

In answer to #1, I've added the other method and updated the tests :) I also removed the `opts` param as it wasn't being used. The `then-request` package comes from a mention in the `sync-request` package's README.

I hope you like it!
